### PR TITLE
Expire guages if no updates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import http from "http";
 import dgram from "dgram";
 import { DecodedEvent, Event, decodeEvent } from "./weatherflow.js";
 import { AddressInfo } from "net";
+import { withGaugeWatchdog } from "./metricWatchdog.js";
 
 const metricsServer = http.createServer((__req, res) => {
   res.setHeader("Content-Type", client.register.contentType);
@@ -19,121 +20,167 @@ metricsServer.on("listening", () => {
 
 metricsServer.listen(8080, "0.0.0.0");
 
-const wind_lull = new client.Gauge({
-  name: "weatherflow_wind_lull",
-  help: "wind_lull",
-  labelNames: ["serial_number"],
-});
-const wind_avg = new client.Gauge({
-  name: "weatherflow_wind_avg",
-  help: "wind_avg",
-  labelNames: ["serial_number"],
-});
-const wind_gust = new client.Gauge({
-  name: "weatherflow_wind_gust",
-  help: "wind_gust",
-  labelNames: ["serial_number"],
-});
-const wind_direction = new client.Gauge({
-  name: "weatherflow_wind_direction",
-  help: "wind_direction",
-  labelNames: ["serial_number"],
-});
-const wind_sample_interval = new client.Gauge({
-  name: "weatherflow_wind_sample_interval",
-  help: "wind_sample_interval",
-  labelNames: ["serial_number"],
-});
-const station_pressure = new client.Gauge({
-  name: "weatherflow_station_pressure",
-  help: "station_pressure",
-  labelNames: ["serial_number"],
-});
-const air_temperature = new client.Gauge({
-  name: "weatherflow_air_temperature",
-  help: "air_temperature",
-  labelNames: ["serial_number"],
-});
-const relative_humidity = new client.Gauge({
-  name: "weatherflow_relative_humidity",
-  help: "relative_humidity",
-  labelNames: ["serial_number"],
-});
-const illuminance = new client.Gauge({
-  name: "weatherflow_illuminance",
-  help: "illuminance",
-  labelNames: ["serial_number"],
-});
-const uv = new client.Gauge({
-  name: "weatherflow_uv",
-  help: "uv",
-  labelNames: ["serial_number"],
-});
-const solar_radiation = new client.Gauge({
-  name: "weatherflow_solar_radiation",
-  help: "solar_radiation",
-  labelNames: ["serial_number"],
-});
-const rain_amount = new client.Gauge({
-  name: "weatherflow_rain_amount",
-  help: "rain_amount",
-  labelNames: ["serial_number"],
-});
-const precipitation_type = new client.Gauge({
-  name: "weatherflow_precipitation_type",
-  help: "precipitation_type",
-  labelNames: ["serial_number"],
-});
-const lighting_count = new client.Gauge({
-  name: "weatherflow_lighting_count",
-  help: "lighting_count",
-  labelNames: ["serial_number"],
-});
-const lighting_avg_distance = new client.Gauge({
-  name: "weatherflow_lighting_avg_distance",
-  help: "lighting_avg_distance",
-  labelNames: ["serial_number"],
-});
-const battery = new client.Gauge({
-  name: "weatherflow_battery",
-  help: "battery",
-  labelNames: ["serial_number"],
-});
-const report_interval = new client.Gauge({
-  name: "weatherflow_report_interval",
-  help: "report_interval",
-  labelNames: ["serial_number"],
-});
-const uptime = new client.Gauge({
-  name: "weatherflow_uptime",
-  help: "uptime",
-  labelNames: ["serial_number"],
-});
-const voltage = new client.Gauge({
-  name: "weatherflow_voltage",
-  help: "voltage",
-  labelNames: ["serial_number"],
-});
-const firmware_revision = new client.Gauge({
-  name: "weatherflow_firmware_revision",
-  help: "firmware_revision",
-  labelNames: ["serial_number"],
-});
-const rssi = new client.Gauge({
-  name: "weatherflow_rssi",
-  help: "rssi",
-  labelNames: ["serial_number"],
-});
-const hub_rssi = new client.Gauge({
-  name: "weatherflow_hub_rssi",
-  help: "hub_rssi",
-  labelNames: ["serial_number"],
-});
-const sensor_status = new client.Gauge({
-  name: "weatherflow_sensor_status",
-  help: "sensor_status",
-  labelNames: ["serial_number", "diagnostic"],
-});
+const wind_lull = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_wind_lull",
+    help: "wind_lull",
+    labelNames: ["serial_number"],
+  })
+);
+const wind_avg = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_wind_avg",
+    help: "wind_avg",
+    labelNames: ["serial_number"],
+  })
+);
+const wind_gust = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_wind_gust",
+    help: "wind_gust",
+    labelNames: ["serial_number"],
+  })
+);
+const wind_direction = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_wind_direction",
+    help: "wind_direction",
+    labelNames: ["serial_number"],
+  })
+);
+const wind_sample_interval = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_wind_sample_interval",
+    help: "wind_sample_interval",
+    labelNames: ["serial_number"],
+  })
+);
+const station_pressure = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_station_pressure",
+    help: "station_pressure",
+    labelNames: ["serial_number"],
+  })
+);
+const air_temperature = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_air_temperature",
+    help: "air_temperature",
+    labelNames: ["serial_number"],
+  })
+);
+const relative_humidity = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_relative_humidity",
+    help: "relative_humidity",
+    labelNames: ["serial_number"],
+  })
+);
+const illuminance = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_illuminance",
+    help: "illuminance",
+    labelNames: ["serial_number"],
+  })
+);
+const uv = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_uv",
+    help: "uv",
+    labelNames: ["serial_number"],
+  })
+);
+const solar_radiation = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_solar_radiation",
+    help: "solar_radiation",
+    labelNames: ["serial_number"],
+  })
+);
+const rain_amount = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_rain_amount",
+    help: "rain_amount",
+    labelNames: ["serial_number"],
+  })
+);
+const precipitation_type = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_precipitation_type",
+    help: "precipitation_type",
+    labelNames: ["serial_number"],
+  })
+);
+const lighting_count = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_lighting_count",
+    help: "lighting_count",
+    labelNames: ["serial_number"],
+  })
+);
+const lighting_avg_distance = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_lighting_avg_distance",
+    help: "lighting_avg_distance",
+    labelNames: ["serial_number"],
+  })
+);
+const battery = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_battery",
+    help: "battery",
+    labelNames: ["serial_number"],
+  })
+);
+const report_interval = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_report_interval",
+    help: "report_interval",
+    labelNames: ["serial_number"],
+  })
+);
+const uptime = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_uptime",
+    help: "uptime",
+    labelNames: ["serial_number"],
+  })
+);
+const voltage = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_voltage",
+    help: "voltage",
+    labelNames: ["serial_number"],
+  })
+);
+const firmware_revision = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_firmware_revision",
+    help: "firmware_revision",
+    labelNames: ["serial_number"],
+  })
+);
+const rssi = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_rssi",
+    help: "rssi",
+    labelNames: ["serial_number"],
+  })
+);
+const hub_rssi = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_hub_rssi",
+    help: "hub_rssi",
+    labelNames: ["serial_number"],
+  })
+);
+const sensor_status = withGaugeWatchdog(
+  new client.Gauge({
+    name: "weatherflow_sensor_status",
+    help: "sensor_status",
+    labelNames: ["serial_number", "diagnostic"],
+  })
+);
 const server = dgram.createSocket("udp4");
 
 async function submitEvent(event: DecodedEvent) {
@@ -141,86 +188,85 @@ async function submitEvent(event: DecodedEvent) {
   if (event.type === "obs_st") {
     const obs = event.observations[event.observations.length - 1]!;
     if (obs.windLull != null) {
-      wind_lull
-        .labels({ serial_number: event.serial_number })
-        .set(obs.windLull);
+      wind_lull.set({ serial_number: event.serial_number }, obs.windLull);
     } else {
       wind_lull.remove({ serial_number: event.serial_number });
     }
     if (obs.windAvg != null) {
-      wind_avg.labels({ serial_number: event.serial_number }).set(obs.windAvg);
+      wind_avg.set({ serial_number: event.serial_number }, obs.windAvg);
     } else {
       wind_avg.remove({ serial_number: event.serial_number });
     }
     if (obs.windGust != null) {
-      wind_gust
-        .labels({ serial_number: event.serial_number })
-        .set(obs.windGust);
+      wind_gust.set({ serial_number: event.serial_number }, obs.windGust);
     } else {
       wind_gust.remove({ serial_number: event.serial_number });
     }
     if (obs.windDirection != null) {
-      wind_direction
-        .labels({ serial_number: event.serial_number })
-        .set(obs.windDirection);
+      wind_direction.set(
+        { serial_number: event.serial_number },
+        obs.windDirection
+      );
     } else {
       wind_direction.remove({ serial_number: event.serial_number });
     }
     if (obs.windSampleInterval != null) {
-      wind_sample_interval
-        .labels({ serial_number: event.serial_number })
-        .set(obs.windSampleInterval);
+      wind_sample_interval.set(
+        { serial_number: event.serial_number },
+        obs.windSampleInterval
+      );
     } else {
       wind_sample_interval.remove({ serial_number: event.serial_number });
     }
     if (obs.stationPressure != null) {
-      station_pressure
-        .labels({ serial_number: event.serial_number })
-        .set(obs.stationPressure);
+      station_pressure.set(
+        { serial_number: event.serial_number },
+        obs.stationPressure
+      );
     } else {
       station_pressure.remove({ serial_number: event.serial_number });
     }
     if (obs.temperature != null) {
-      air_temperature
-        .labels({ serial_number: event.serial_number })
-        .set(obs.temperature);
+      air_temperature.set(
+        { serial_number: event.serial_number },
+        obs.temperature
+      );
     } else {
       air_temperature.remove({ serial_number: event.serial_number });
     }
     if (obs.humidity != null) {
-      relative_humidity
-        .labels({ serial_number: event.serial_number })
-        .set(obs.humidity);
+      relative_humidity.set(
+        { serial_number: event.serial_number },
+        obs.humidity
+      );
     } else {
       relative_humidity.remove({ serial_number: event.serial_number });
     }
     if (obs.illuminance != null) {
-      illuminance
-        .labels({ serial_number: event.serial_number })
-        .set(obs.illuminance);
+      illuminance.set({ serial_number: event.serial_number }, obs.illuminance);
     } else {
       illuminance.remove({ serial_number: event.serial_number });
     }
     if (obs.uvIndex != null) {
-      uv.labels({ serial_number: event.serial_number }).set(obs.uvIndex);
+      uv.set({ serial_number: event.serial_number }, obs.uvIndex);
     } else {
       uv.remove({ serial_number: event.serial_number });
     }
     if (obs.solarRadiation != null) {
-      solar_radiation
-        .labels({ serial_number: event.serial_number })
-        .set(obs.solarRadiation);
+      solar_radiation.set(
+        { serial_number: event.serial_number },
+        obs.solarRadiation
+      );
     } else {
       solar_radiation.remove({ serial_number: event.serial_number });
     }
     if (obs.rainAmount != null) {
-      rain_amount
-        .labels({ serial_number: event.serial_number })
-        .set(obs.rainAmount);
+      rain_amount.set({ serial_number: event.serial_number }, obs.rainAmount);
     } else {
       rain_amount.remove({ serial_number: event.serial_number });
     }
-    precipitation_type.labels({ serial_number: event.serial_number }).set(
+    precipitation_type.set(
+      { serial_number: event.serial_number },
       (() => {
         switch (obs.precipitationType) {
           case "none":
@@ -235,99 +281,107 @@ async function submitEvent(event: DecodedEvent) {
       })()
     );
     if (obs.lightningCount != null) {
-      lighting_count
-        .labels({ serial_number: event.serial_number })
-        .set(obs.lightningCount);
+      lighting_count.set(
+        { serial_number: event.serial_number },
+        obs.lightningCount
+      );
     } else {
       lighting_count.remove({ serial_number: event.serial_number });
     }
     if (obs.lightningAvgDistance != null) {
-      lighting_avg_distance
-        .labels({ serial_number: event.serial_number })
-        .set(obs.lightningAvgDistance);
+      lighting_avg_distance.set(
+        { serial_number: event.serial_number },
+        obs.lightningAvgDistance
+      );
     } else {
       lighting_avg_distance.remove({ serial_number: event.serial_number });
     }
     if (obs.battery != null) {
-      battery.labels({ serial_number: event.serial_number }).set(obs.battery);
+      battery.set({ serial_number: event.serial_number }, obs.battery);
     } else {
       battery.remove({ serial_number: event.serial_number });
     }
     if (obs.reportInterval != null) {
-      report_interval
-        .labels({ serial_number: event.serial_number })
-        .set(obs.reportInterval);
+      report_interval.set(
+        { serial_number: event.serial_number },
+        obs.reportInterval
+      );
     } else {
       report_interval.remove({ serial_number: event.serial_number });
     }
   } else if (event.type == "device_status") {
-    uptime.labels({ serial_number: event.serial_number }).set(event.uptime);
-    voltage.labels({ serial_number: event.serial_number }).set(event.voltage);
-    firmware_revision
-      .labels({ serial_number: event.serial_number })
-      .set(event.firmware_revision);
-    rssi.labels({ serial_number: event.serial_number }).set(event.rssi);
-    hub_rssi.labels({ serial_number: event.serial_number }).set(event.hub_rssi);
-    sensor_status
-      .labels({
-        serial_number: event.serial_number,
-        diagnostic: "sensors_ok",
-      })
-      .set(event.sensor_status.sensors_ok ? 1 : 0);
-    sensor_status
-      .labels({
+    uptime.set({ serial_number: event.serial_number }, event.uptime);
+    voltage.set({ serial_number: event.serial_number }, event.voltage);
+    firmware_revision.set(
+      { serial_number: event.serial_number },
+      event.firmware_revision
+    );
+    rssi.set({ serial_number: event.serial_number }, event.rssi);
+    hub_rssi.set({ serial_number: event.serial_number }, event.hub_rssi);
+    sensor_status.set(
+      { serial_number: event.serial_number, diagnostic: "sensors_ok" },
+      event.sensor_status.sensors_ok ? 1 : 0
+    );
+    sensor_status.set(
+      {
         serial_number: event.serial_number,
         diagnostic: "lightning_sensor_failed",
-      })
-      .set(event.sensor_status.lightning_sensor_failed ? 1 : 0);
-    sensor_status
-      .labels({
+      },
+      event.sensor_status.lightning_sensor_failed ? 1 : 0
+    );
+    sensor_status.set(
+      {
         serial_number: event.serial_number,
         diagnostic: "lightning_sensor_noise",
-      })
-      .set(event.sensor_status.lightning_sensor_noise ? 1 : 0);
-    sensor_status
-      .labels({
+      },
+      event.sensor_status.lightning_sensor_noise ? 1 : 0
+    );
+    sensor_status.set(
+      {
         serial_number: event.serial_number,
         diagnostic: "lightning_sensor_disturbance",
-      })
-      .set(event.sensor_status.lightning_sensor_disturbance ? 1 : 0);
-    sensor_status
-      .labels({
+      },
+      event.sensor_status.lightning_sensor_disturbance ? 1 : 0
+    );
+    sensor_status.set(
+      {
         serial_number: event.serial_number,
         diagnostic: "pressure_sensor_failed",
-      })
-      .set(event.sensor_status.pressure_sensor_failed ? 1 : 0);
-    sensor_status
-      .labels({
+      },
+      event.sensor_status.pressure_sensor_failed ? 1 : 0
+    );
+    sensor_status.set(
+      {
         serial_number: event.serial_number,
         diagnostic: "temperature_sensor_failed",
-      })
-      .set(event.sensor_status.temperature_sensor_failed ? 1 : 0);
-    sensor_status
-      .labels({
+      },
+      event.sensor_status.temperature_sensor_failed ? 1 : 0
+    );
+    sensor_status.set(
+      {
         serial_number: event.serial_number,
         diagnostic: "humidity_sensor_failed",
-      })
-      .set(event.sensor_status.humidity_sensor_failed ? 1 : 0);
-    sensor_status
-      .labels({
-        serial_number: event.serial_number,
-        diagnostic: "wind_sensor_failed",
-      })
-      .set(event.sensor_status.wind_sensor_failed ? 1 : 0);
-    sensor_status
-      .labels({
+      },
+      event.sensor_status.humidity_sensor_failed ? 1 : 0
+    );
+    sensor_status.set(
+      { serial_number: event.serial_number, diagnostic: "wind_sensor_failed" },
+      event.sensor_status.wind_sensor_failed ? 1 : 0
+    );
+    sensor_status.set(
+      {
         serial_number: event.serial_number,
         diagnostic: "precipitation_sensor_failed",
-      })
-      .set(event.sensor_status.precipitation_sensor_failed ? 1 : 0);
-    sensor_status
-      .labels({
+      },
+      event.sensor_status.precipitation_sensor_failed ? 1 : 0
+    );
+    sensor_status.set(
+      {
         serial_number: event.serial_number,
         diagnostic: "light_uv_sensor_failed",
-      })
-      .set(event.sensor_status.light_uv_sensor_failed ? 1 : 0);
+      },
+      event.sensor_status.light_uv_sensor_failed ? 1 : 0
+    );
   }
 }
 

--- a/src/metricWatchdog.ts
+++ b/src/metricWatchdog.ts
@@ -1,0 +1,41 @@
+import client from "prom-client";
+
+const TWO_MINUTES_IN_MS = 2 * 60 * 1000;
+
+export function withGaugeWatchdog<T extends string>(
+  metric: client.Gauge<T>,
+  timeout: number = TWO_MINUTES_IN_MS
+) {
+  const lastSeenMap: Map<string, Date> = new Map();
+
+  setInterval(() => {
+    for (const key of lastSeenMap.keys()) {
+      if (lastSeenMap.get(key)!.getTime() + timeout < new Date().getTime()) {
+        // console.log(
+        //   "watchdog remove",
+        //   // @ts-expect-error private for debugging
+        //   metric.name,
+        //   "with labels",
+        //   JSON.parse(key)
+        // );
+        lastSeenMap.delete(key);
+        metric.remove(JSON.parse(key));
+      }
+    }
+  }, 500);
+
+  return {
+    set(labels: Record<T, string | number>, value: number) {
+      // // @ts-expect-error private for debugging
+      // console.log("seen", metric.name, "with labels", labels);
+      lastSeenMap.set(JSON.stringify(labels), new Date());
+      metric.set(labels, value);
+    },
+    remove(labels: Record<T, string | number>) {
+      // // @ts-expect-error private for debugging
+      // console.log("manual remove", metric.name, "with labels", labels);
+      lastSeenMap.delete(JSON.stringify(labels));
+      metric.remove(labels);
+    },
+  };
+}

--- a/src/metricWatchdog.ts
+++ b/src/metricWatchdog.ts
@@ -1,6 +1,7 @@
 import client from "prom-client";
 
 const TWO_MINUTES_IN_MS = 2 * 60 * 1000;
+const WATCHDOG_CHECK_INTERVAL = 500;
 
 export function withGaugeWatchdog<T extends string>(
   metric: client.Gauge<T>,
@@ -11,29 +12,18 @@ export function withGaugeWatchdog<T extends string>(
   setInterval(() => {
     for (const key of lastSeenMap.keys()) {
       if (lastSeenMap.get(key)!.getTime() + timeout < new Date().getTime()) {
-        // console.log(
-        //   "watchdog remove",
-        //   // @ts-expect-error private for debugging
-        //   metric.name,
-        //   "with labels",
-        //   JSON.parse(key)
-        // );
         lastSeenMap.delete(key);
         metric.remove(JSON.parse(key));
       }
     }
-  }, 500);
+  }, WATCHDOG_CHECK_INTERVAL);
 
   return {
     set(labels: Record<T, string | number>, value: number) {
-      // // @ts-expect-error private for debugging
-      // console.log("seen", metric.name, "with labels", labels);
       lastSeenMap.set(JSON.stringify(labels), new Date());
       metric.set(labels, value);
     },
     remove(labels: Record<T, string | number>) {
-      // // @ts-expect-error private for debugging
-      // console.log("manual remove", metric.name, "with labels", labels);
       lastSeenMap.delete(JSON.stringify(labels));
       metric.remove(labels);
     },


### PR DESCRIPTION
Noticed that our data seemed to get "stuck" on a value and just flatlined. Debugging a bit further, it seems that the Tempest stopped sending UDP messages but unfortunately my alerting didn't fire because there were still metrics being published, just stale values. This is because the gauge will hold onto the previous value indefinitely and never expire it (which makes sense in some situations, but not others).

![image](https://github.com/kj800x/weatherflow-tempest-influxdb-integration/assets/1657142/389582f8-2569-4271-809f-2a34b0a26b15)

This PR [wraps](https://github.com/kj800x/weatherflow-tempest-influxdb-integration/blob/85104c600f0a1e62ff66fe625062590c6d3c4b73/src/metricWatchdog.ts#L6) the `prom-client` Gauge instances to keep track of the "last seen" time. If a guage hasn't been updated in a given period, it will automatically remove it. Once the gauge is set again, it will reset the "last seen" time and publish the gauge's value for another `timeout` period. It doesn't solve the underlying issue with the Tempest failing to publish UDP messages, but it should make the rest of the ingestion / alerting pipeline better by correctly clearing those metrics if we haven't gotten an update.

Other metrics libraries have this feature built-in, such as [Rust's `metrics`](https://docs.rs/metrics/latest/metrics/) ([see example usage here](https://github.com/kj800x/prom-money-rs/blob/f0a51121480ca5461a72333b10383af7f976139d/src/main.rs#L37)). It doesn't seem that npm's `prom-client` supports this feature, so I may consider filing a feature request to see the feasibility. This feature should be possible to add in a backwards compatible way (by default, don't expire metrics).