### PR TITLE
Switch Docker build cache from GHA to ghcr registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -88,8 +88,8 @@ jobs:
             ${{ steps.meta.outputs.tags }}
             ghcr.io/${{ github.repository }}:commit-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}:buildcache,mode=max', env.IMAGE_NAME) || '' }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
GitHub Actions cache evicts entries after 7 days of inactivity (and is capped at 10 GB per repo). For projects with multi-week commit gaps, that turns every "first push after a quiet stretch" into a cold rebuild.

Registry-backed cache stores the BuildKit cache as an OCI artifact in ghcr and has no TTL, so it survives long gaps. PR builds read the cache but don't write to it (avoids polluting main's cache with WIP layers and sidesteps fork PRs lacking packages:write).

Part of kj800x/homelab#2.